### PR TITLE
Support private container registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ No modules.
 | <a name="input_azcopy_url"></a> [azcopy\_url](#input\_azcopy\_url) | URL to download azcopy binary | `string` | `"https://nf-xpack.seqera.io/azcopy/linux_amd64_10.8.0/azcopy"` | no |
 | <a name="input_batch_account_name"></a> [batch\_account\_name](#input\_batch\_account\_name) | Name of the existing Batch account | `string` | `"seqeracomputebatch"` | no |
 | <a name="input_batch_pool_name"></a> [batch\_pool\_name](#input\_batch\_pool\_name) | Name of the Batch pool to be created | `string` | `"seqerapool"` | no |
+| <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. | <pre>list(object({<br>    registry_server = string<br>    user_name       = string<br>    password        = string<br>  }))</pre> | `[]` | no |
 | <a name="input_create_seqera_compute_env"></a> [create\_seqera\_compute\_env](#input\_create\_seqera\_compute\_env) | Whether to create a seqera compute environment | `bool` | `false` | no |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | Name of the managed identity to use with Azure Batch | `string` | `"nextflow-id"` | no |
 | <a name="input_managed_identity_resource_group"></a> [managed\_identity\_resource\_group](#input\_managed\_identity\_resource\_group) | Resource group containing the managed identity | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ managed_identity_name           = "managed-identity-name"
 managed_identity_resource_group = "managed-identity-resource-group"
 
 # Optional container registries configuration
+# Can use:
+# 1) username AND password
+# 2) identity_id
+# 3) use_managed_identity = true (pool's managed identity will be used)
 container_registries = [
   {
     registry_server = "my-registry-server.azurecr.io"
@@ -58,6 +62,10 @@ container_registries = [
   {
     registry_server = "my-registry-server.azurecr.io"
     identity_id     = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-managed-identity"
+  },
+  {
+    registry_server     = "my-registry-server.azurecr.io"
+    use_managed_identity = true
   }
 ]
 ```
@@ -135,7 +143,7 @@ No modules.
 | <a name="input_azcopy_url"></a> [azcopy\_url](#input\_azcopy\_url) | URL to download azcopy binary | `string` | `"https://nf-xpack.seqera.io/azcopy/linux_amd64_10.8.0/azcopy"` | no |
 | <a name="input_batch_account_name"></a> [batch\_account\_name](#input\_batch\_account\_name) | Name of the existing Batch account | `string` | `"seqeracomputebatch"` | no |
 | <a name="input_batch_pool_name"></a> [batch\_pool\_name](#input\_batch\_pool\_name) | Name of the Batch pool to be created | `string` | `"seqerapool"` | no |
-| <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. For each registry, provide either username+password OR identity\_id, not both. | <pre>list(object({<br>    registry_server = string<br>    user_name       = optional(string)<br>    password        = optional(string)<br>    identity_id     = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. For each registry, provide either username+password OR set use\_managed\_identity to true. When use\_managed\_identity is true, the pool's managed identity will be used. | <pre>list(object({<br>    registry_server      = string<br>    user_name            = optional(string)<br>    password             = optional(string)<br>    identity_id          = optional(string)<br>    use_managed_identity = optional(bool, false)<br>  }))</pre> | `[]` | no |
 | <a name="input_create_seqera_compute_env"></a> [create\_seqera\_compute\_env](#input\_create\_seqera\_compute\_env) | Whether to create a seqera compute environment | `bool` | `false` | no |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | Name of the managed identity to use with Azure Batch | `string` | `"nextflow-id"` | no |
 | <a name="input_managed_identity_resource_group"></a> [managed\_identity\_resource\_group](#input\_managed\_identity\_resource\_group) | Resource group containing the managed identity | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ subnet_id = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/pr
 # Optional managed identity configuration
 managed_identity_name           = "managed-identity-name"
 managed_identity_resource_group = "managed-identity-resource-group"
+
+# Optional container registries configuration
+container_registries = [
+  {
+    registry_server = "my-registry-server.azurecr.io"
+    user_name       = "my-username"
+    password        = "my-password"
+  },
+  {
+    registry_server = "my-registry-server.azurecr.io"
+    identity_id     = "/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-managed-identity"
+  }
+]
 ```
 
 If you want to add the compute pool to Seqera Platform, you can set the following variables:
@@ -122,7 +135,7 @@ No modules.
 | <a name="input_azcopy_url"></a> [azcopy\_url](#input\_azcopy\_url) | URL to download azcopy binary | `string` | `"https://nf-xpack.seqera.io/azcopy/linux_amd64_10.8.0/azcopy"` | no |
 | <a name="input_batch_account_name"></a> [batch\_account\_name](#input\_batch\_account\_name) | Name of the existing Batch account | `string` | `"seqeracomputebatch"` | no |
 | <a name="input_batch_pool_name"></a> [batch\_pool\_name](#input\_batch\_pool\_name) | Name of the Batch pool to be created | `string` | `"seqerapool"` | no |
-| <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. | <pre>list(object({<br>    registry_server = string<br>    user_name       = string<br>    password        = string<br>  }))</pre> | `[]` | no |
+| <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. For each registry, provide either username+password OR identity\_id, not both. | <pre>list(object({<br>    registry_server = string<br>    user_name       = optional(string)<br>    password        = optional(string)<br>    identity_id     = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_create_seqera_compute_env"></a> [create\_seqera\_compute\_env](#input\_create\_seqera\_compute\_env) | Whether to create a seqera compute environment | `bool` | `false` | no |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | Name of the managed identity to use with Azure Batch | `string` | `"nextflow-id"` | no |
 | <a name="input_managed_identity_resource_group"></a> [managed\_identity\_resource\_group](#input\_managed\_identity\_resource\_group) | Resource group containing the managed identity | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "azurerm_batch_pool" "pool" {
         registry_server           = container_registries.value.registry_server
         user_name                 = container_registries.value.user_name != null ? container_registries.value.user_name : null
         password                  = container_registries.value.password != null ? container_registries.value.password : null
-        user_assigned_identity_id = container_registries.value.identity_id != null ? container_registries.value.identity_id : null
+        user_assigned_identity_id = container_registries.value.identity_id != null ? container_registries.value.identity_id : (container_registries.value.use_managed_identity ? data.azurerm_user_assigned_identity.mi.id : null)
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,14 @@ resource "azurerm_batch_pool" "pool" {
   # Container configuration for Docker support
   container_configuration {
     type = "DockerCompatible"
+    dynamic "container_registries" {
+      for_each = var.container_registries
+      content {
+        registry_server = container_registries.value.registry_server
+        user_name       = container_registries.value.user_name
+        password        = container_registries.value.password
+      }
+    }
   }
 
   # Auto-scale configuration

--- a/main.tf
+++ b/main.tf
@@ -113,9 +113,10 @@ resource "azurerm_batch_pool" "pool" {
     dynamic "container_registries" {
       for_each = var.container_registries
       content {
-        registry_server = container_registries.value.registry_server
-        user_name       = container_registries.value.user_name
-        password        = container_registries.value.password
+        registry_server           = container_registries.value.registry_server
+        user_name                 = container_registries.value.user_name != null ? container_registries.value.user_name : null
+        password                  = container_registries.value.password != null ? container_registries.value.password : null
+        user_assigned_identity_id = container_registries.value.identity_id != null ? container_registries.value.identity_id : null
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,16 @@ variable "min_pool_size" {
   default     = 0
 }
 
+variable "container_registries" {
+  description = "List of container registries to be used in the Batch pool's container configuration."
+  type = list(object({
+    registry_server = string
+    user_name       = string
+    password        = string
+  }))
+  default = []
+}
+
 variable "create_seqera_compute_env" {
   description = "Whether to create a seqera compute environment"
   type        = bool
@@ -161,3 +171,4 @@ variable "seqera_nextflow_config" {
   default     = null
   nullable    = true
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -88,13 +88,23 @@ variable "min_pool_size" {
 }
 
 variable "container_registries" {
-  description = "List of container registries to be used in the Batch pool's container configuration."
+  description = "List of container registries to be used in the Batch pool's container configuration. For each registry, provide either username+password OR identity_id, not both."
   type = list(object({
     registry_server = string
-    user_name       = string
-    password        = string
+    user_name       = optional(string)
+    password        = optional(string)
+    identity_id     = optional(string)
   }))
   default = []
+
+  validation {
+    condition = alltrue([
+      for registry in var.container_registries :
+      (registry.user_name != null && registry.password != null && registry.identity_id == null) ||
+      (registry.user_name == null && registry.password == null && registry.identity_id != null)
+    ])
+    error_message = "Each registry must have either username AND password OR identity_id, not both or neither."
+  }
 }
 
 variable "create_seqera_compute_env" {


### PR DESCRIPTION
This PR adds support for private registries.

They can be configured with:
- username + password (token)
- A manually selected managed identity
- Automatically using the managed identity added as part of pool configuration