### PR TITLE
feat: add dual pool mode for head/worker Batch pools

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -21,28 +21,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
-provider "registry.terraform.io/mastercard/restapi" {
-  version = "3.0.0"
-  hashes = [
-    "h1:y1I3azDHOqRySTyDHsb3Xh1waP/99KfykZRagbRx1qI=",
-    "zh:0b63bd3c25a31f090a41933f90b7dd6e984add1c4261d8f5caa73f4d5aa065a4",
-    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
-    "zh:2d31f322454d271eb328c2d3b3d41f426df98503982788be347799ddf68bf9bf",
-    "zh:47dd97e3f43bb89ae4254bba90ffbc6d521338554a1f94961e21214dd801b81b",
-    "zh:49636b072b9a30d15916468857bce91d39bc87bbba1c99fb3894fafa9409b8b4",
-    "zh:5566605a8e16478bc66c1fec8dea0890586c084221161dc82b73d162d44c08a7",
-    "zh:5859e0ad05aa6b3b108f0b718986e237a18d5176efea62d1ac1ef352561b4713",
-    "zh:76129b89e2b56d8d2af8f6e10cc748bea4ee6ec1105e916f1254cd124f4dcf9c",
-    "zh:bfc20b5fd03cb3243917e8cf360e5208284e757ab82f83c992da471ef16a0eab",
-    "zh:d1d2363009253cdfe5795a48b6412bff11104fe6a52fb0a57e5a95fc765a161e",
-    "zh:d1f0b981089ad709b73c4f989a9cd9118c4e3cb8fc0a2b303aa4d77cc5102a53",
-    "zh:dbfddb2f407481a4e88fdc17739c805d9d9fff2451efcb9226572d59ed2e9128",
-    "zh:df04a8c777d05896684171807b27c41befbf5f217f50b0e9b2b27164d4aacca5",
-    "zh:e68b450c66efe55d1132585477fa71207680806edafb3792ca44d9695d0a1d75",
-    "zh:f894e7e9913347e25e67d5d3bf91659c06877dd5fa11acf75820fa03fa34b8bd",
-  ]
-}
-
 provider "registry.terraform.io/seqeralabs/seqera" {
   version     = "0.41.0"
   constraints = "~> 0.41.0"

--- a/README.md
+++ b/README.md
@@ -160,6 +160,50 @@ vm_image_sku      = "2404"
 node_agent_sku_id = "batch.node.ubuntu 24.04"
 ```
 
+### Dual pool mode
+
+Set `enable_dual_pool = true` to create a separate worker pool alongside the existing pool. The existing pool becomes the **head pool**, which runs the Nextflow driver job. Tasks are routed to the **worker pool**. This lets the head node and workers use different VM sizes and different managed identities, which improves both efficiency (a small head node, cheap auto-scaling workers) and security posture (the head identity and worker identity can be scoped separately).
+
+Enabling dual pool mode does not change the existing pool's Terraform state: the head pool keeps the `azurerm_batch_pool.pool` address and the worker pool is added as `azurerm_batch_pool.worker[0]`. With `enable_dual_pool = false` (the default) the module behaves exactly as before.
+
+```terraform
+create_seqera_compute_env = true
+
+# Head pool (existing variables)
+batch_pool_name       = "mypool"
+vm_size               = "Standard_E8d_v5"
+min_pool_size         = 0
+max_pool_size         = 1
+managed_identity_name = "nextflow-head-id"
+
+# Worker pool
+enable_dual_pool             = true
+worker_vm_size               = "Standard_E16d_v5"
+worker_min_pool_size         = 0
+worker_max_pool_size         = 8
+worker_managed_identity_name = "nextflow-worker-id" # recommended: a distinct identity
+```
+
+Both managed identities must already exist and be resolvable via the `azurerm_user_assigned_identity` data source (name plus resource group). This module references the identities; it does not create them or assign their roles. If `worker_managed_identity_name` is omitted, the worker pool reuses the head identity, which removes the security benefit.
+
+#### Required role assignments
+
+The security benefit of dual pool mode comes entirely from scoping the two identities differently. Assign these roles (outside this module) before running a pipeline:
+
+| Identity | Role | Scope | Why |
+|----------|------|-------|-----|
+| Head (`managed_identity_name`) | Storage Blob Data Contributor | Work-directory storage account | Head node reads/writes the work directory |
+| Head (`managed_identity_name`) | Azure Batch Data Contributor | Batch account | Head node (Nextflow driver) submits tasks to the worker pool |
+| Worker (`worker_managed_identity_name`) | Storage Blob Data Contributor | Work-directory storage account | Workers read/write the work directory |
+
+The worker identity deliberately gets **no Batch role** — workers only move data, they never talk to the Batch API. That least-privilege split is the point of using a separate worker identity; reusing the head identity for both pools gives every task node full Batch data-plane access.
+
+#### Provider field mapping
+
+The head/worker pool names and the per-pool managed-identity fields are set on the `seqera_compute_env` resource using the `seqeralabs/seqera` provider's manual (named-pool) config. `head_pool`, `worker_pool`, `managed_identity_client_id`, `managed_identity_head_resource_id`, `managed_identity_pool_client_id`, and `managed_identity_pool_resource_id` are all sibling `config.azure_batch` attributes at v0.41.x, so manual named pools and per-pool identities compose. `managed_identity_client_id` + `managed_identity_head_resource_id` identify the head (driver) identity; `managed_identity_pool_client_id` + `managed_identity_pool_resource_id` identify the worker-pool identity.
+
+> **Verify runtime behaviour before production use.** This four-field identity mapping matches a working Batch Forge dual-pool deployment, but Forge auto-creates its pools whereas this module wires the identities to manually created named pools. Run `terraform plan` and a test pipeline against a real workspace to confirm before relying on this in production.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -185,6 +229,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_batch_pool.pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/batch_pool) | resource |
+| [azurerm_batch_pool.worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/batch_pool) | resource |
 | [seqera_compute_env.azure_batch](https://registry.terraform.io/providers/seqeralabs/seqera/latest/docs/resources/compute_env) | resource |
 
 ## Inputs
@@ -195,7 +240,9 @@ No modules.
 | <a name="input_batch_pool_name"></a> [batch\_pool\_name](#input\_batch\_pool\_name) | Name of the Batch pool to be created | `string` | n/a | yes |
 | <a name="input_container_registries"></a> [container\_registries](#input\_container\_registries) | List of container registries to be used in the Batch pool's container configuration. For each registry, provide either username+password OR set use\_managed\_identity to true. When use\_managed\_identity is true, the pool's managed identity will be used. | <pre>list(object({<br>    registry_server      = string<br>    user_name            = optional(string)<br>    password             = optional(string)<br>    identity_id          = optional(string)<br>    use_managed_identity = optional(bool, false)<br>  }))</pre> | `[]` | no |
 | <a name="input_create_seqera_compute_env"></a> [create\_seqera\_compute\_env](#input\_create\_seqera\_compute\_env) | Whether to create a seqera compute environment | `bool` | `false` | no |
-| <a name="input_enable_fusion"></a> [enable\_fusion](#input\_enable\_fusion) | Enable Fusion v2 support in the compute environment. | `bool` | `false` | no |
+| <a name="input_enable_dual_pool"></a> [enable\_dual\_pool](#input\_enable\_dual\_pool) | Enable dual pool mode: create a separate worker pool alongside the existing (head) pool. The head pool runs the Nextflow driver job and tasks are routed to the worker pool. Defaults to false, in which case the module behaves exactly as before (single pool). | `bool` | `false` | no |
+| <a name="input_enable_fusion"></a> [enable\_fusion](#input\_enable\_fusion) | Enable Fusion v2 support in the compute environment. Implies enable\_wave (Fusion requires Wave). | `bool` | `false` | no |
+| <a name="input_enable_wave"></a> [enable\_wave](#input\_enable\_wave) | Enable the Wave container service in the compute environment. Automatically enabled when enable\_fusion is true; set independently to use Wave without Fusion. | `bool` | `false` | no |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | Name of the managed identity to use with Azure Batch | `string` | `"nextflow-id"` | no |
 | <a name="input_managed_identity_resource_group"></a> [managed\_identity\_resource\_group](#input\_managed\_identity\_resource\_group) | Resource group containing the managed identity | `string` | `null` | no |
 | <a name="input_max_pool_size"></a> [max\_pool\_size](#input\_max\_pool\_size) | Maximum number of VMs in the pool | `number` | `8` | no |
@@ -221,6 +268,12 @@ No modules.
 | <a name="input_vm_image_sku"></a> [vm\_image\_sku](#input\_vm\_image\_sku) | SKU of the VM image | `string` | `"2404"` | no |
 | <a name="input_vm_image_version"></a> [vm\_image\_version](#input\_vm\_image\_version) | Version of the VM image | `string` | `"latest"` | no |
 | <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | Size of the VM to use in the Batch pool | `string` | `"Standard_E16d_v5"` | no |
+| <a name="input_worker_managed_identity_name"></a> [worker\_managed\_identity\_name](#input\_worker\_managed\_identity\_name) | Name of a separate managed identity for the worker pool (dual pool mode). Recommended for the security benefit of dual pool mode. If null, the worker pool reuses the head managed identity. | `string` | `null` | no |
+| <a name="input_worker_managed_identity_resource_group"></a> [worker\_managed\_identity\_resource\_group](#input\_worker\_managed\_identity\_resource\_group) | Resource group containing the worker managed identity. Defaults to managed\_identity\_resource\_group if not set. | `string` | `null` | no |
+| <a name="input_worker_max_pool_size"></a> [worker\_max\_pool\_size](#input\_worker\_max\_pool\_size) | Maximum number of VMs in the worker pool (dual pool mode). | `number` | `8` | no |
+| <a name="input_worker_min_pool_size"></a> [worker\_min\_pool\_size](#input\_worker\_min\_pool\_size) | Minimum number of VMs in the worker pool (dual pool mode). | `number` | `0` | no |
+| <a name="input_worker_pool_name"></a> [worker\_pool\_name](#input\_worker\_pool\_name) | Name of the worker Batch pool (dual pool mode). Defaults to '<batch\_pool\_name>-worker' if not set. | `string` | `null` | no |
+| <a name="input_worker_vm_size"></a> [worker\_vm\_size](#input\_worker\_vm\_size) | VM size for the worker pool (dual pool mode). Defaults to Standard\_E16d\_v5 (the same default as the head vm\_size); set explicitly to give workers a different size than the head node. | `string` | `"Standard_E16d_v5"` | no |
 
 ## Outputs
 
@@ -231,4 +284,7 @@ No modules.
 | <a name="output_credentials_id"></a> [credentials\_id](#output\_credentials\_id) | The ID of the credentials |
 | <a name="output_managed_identity_client_id"></a> [managed\_identity\_client\_id](#output\_managed\_identity\_client\_id) | The client ID of the managed identity |
 | <a name="output_seqera_compute_env_id"></a> [seqera\_compute\_env\_id](#output\_seqera\_compute\_env\_id) | The ID of the Seqera compute environment |
+| <a name="output_worker_managed_identity_client_id"></a> [worker\_managed\_identity\_client\_id](#output\_worker\_managed\_identity\_client\_id) | The client ID of the managed identity used by the worker pool (null unless dual pool mode is enabled) |
+| <a name="output_worker_pool_id"></a> [worker\_pool\_id](#output\_worker\_pool\_id) | The ID of the worker Azure Batch pool (null unless dual pool mode is enabled) |
+| <a name="output_worker_pool_name"></a> [worker\_pool\_name](#output\_worker\_pool\_name) | The name of the worker Azure Batch pool (null unless dual pool mode is enabled) |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,13 @@ locals {
   slots            = can(regex("[A-Za-z]+[Ss]?(\\d+)", var.vm_size)) ? tonumber(regex("[A-Za-z]+[Ss]?(\\d+)", var.vm_size)[0]) : 1
   compute_env_name = coalesce(var.seqera_compute_env_name, var.batch_pool_name)
 
+  # Worker pool configuration (dual pool mode)
+  worker_pool_name             = var.enable_dual_pool ? coalesce(var.worker_pool_name, "${var.batch_pool_name}-worker") : null
+  worker_slots                 = can(regex("[A-Za-z]+[Ss]?(\\d+)", var.worker_vm_size)) ? tonumber(regex("[A-Za-z]+[Ss]?(\\d+)", var.worker_vm_size)[0]) : 1
+  use_separate_worker_identity = var.enable_dual_pool && var.worker_managed_identity_name != null
+  worker_identity_id           = local.use_separate_worker_identity ? data.azurerm_user_assigned_identity.worker_mi[0].id : data.azurerm_user_assigned_identity.mi.id
+  worker_identity_client_id    = local.use_separate_worker_identity ? data.azurerm_user_assigned_identity.worker_mi[0].client_id : data.azurerm_user_assigned_identity.mi.client_id
+
   # AppArmor profile required for Fusion to mount its FUSE filesystem on hosts
   # that enforce AppArmor (Ubuntu 24.04+). Seqera Platform automatically passes
   # `--security-opt apparmor=seqera-fusionfs-container` to task containers when
@@ -164,6 +171,96 @@ resource "azurerm_batch_pool" "pool" {
   }
 }
 
+# Worker pool (dual pool mode only)
+resource "azurerm_batch_pool" "worker" {
+  count = var.enable_dual_pool ? 1 : 0
+
+  name                = local.worker_pool_name
+  resource_group_name = var.resource_group_name
+  account_name        = var.batch_account_name
+  display_name        = "Seqera Worker Pool"
+  vm_size             = var.worker_vm_size
+  node_agent_sku_id   = var.node_agent_sku_id
+  max_tasks_per_node  = local.worker_slots
+
+  dynamic "network_configuration" {
+    for_each = var.subnet_id != null ? [1] : []
+    content {
+      subnet_id = var.subnet_id
+    }
+  }
+
+  dynamic "identity" {
+    for_each = var.managed_identity_name != "" ? [1] : []
+    content {
+      type         = "UserAssigned"
+      identity_ids = [local.worker_identity_id]
+    }
+  }
+
+  storage_image_reference {
+    publisher = var.vm_image_publisher
+    offer     = var.vm_image_offer
+    sku       = var.vm_image_sku
+    version   = var.vm_image_version
+  }
+
+  container_configuration {
+    type = "DockerCompatible"
+    dynamic "container_registries" {
+      for_each = var.container_registries
+      content {
+        registry_server           = container_registries.value.registry_server
+        user_name                 = container_registries.value.user_name != null ? container_registries.value.user_name : null
+        password                  = container_registries.value.password != null ? container_registries.value.password : null
+        user_assigned_identity_id = container_registries.value.identity_id != null ? container_registries.value.identity_id : (container_registries.value.use_managed_identity ? local.worker_identity_id : null)
+      }
+    }
+  }
+
+  auto_scale {
+    evaluation_interval = "PT5M"
+    formula             = <<EOF
+      // Get pool lifetime since creation.
+      lifespan = time() - time("2024-10-30T00:00:00.880011Z");
+      interval = TimeInterval_Minute * 5;
+
+      // Compute the target nodes based on pending tasks.
+      // $PendingTasks == The sum of $ActiveTasks and $RunningTasks
+      $samples = $PendingTasks.GetSamplePercent(interval);
+      $tasks = $samples < 70 ? max(0, $PendingTasks.GetSample(1)) : max($PendingTasks.GetSample(1), avg($PendingTasks.GetSample(interval)));
+      $targetVMs = $tasks > 0 ? $tasks : max(0, $TargetDedicatedNodes/2);
+      targetPoolSize = max(${var.worker_min_pool_size}, min($targetVMs, ${var.worker_max_pool_size}));
+
+      // For first interval deploy worker_min_pool_size nodes, for other intervals scale up/down as per tasks.
+      $TargetDedicatedNodes = lifespan < interval ? ${var.worker_min_pool_size} : targetPoolSize;
+      $NodeDeallocationOption = taskcompletion;
+    EOF
+  }
+
+  start_task {
+    command_line     = local.start_task_command_line
+    wait_for_success = true
+
+    task_retry_maximum = 0
+
+    user_identity {
+      auto_user {
+        elevation_level = local.start_task_elevation_level
+        scope           = var.start_task_scope
+      }
+    }
+
+    dynamic "resource_file" {
+      for_each = var.start_task_resource_files
+      content {
+        http_url  = resource_file.value.url
+        file_path = resource_file.value.file_path
+      }
+    }
+  }
+}
+
 # Seqera Platform compute environment
 resource "seqera_compute_env" "azure_batch" {
   count        = var.create_seqera_compute_env ? 1 : 0
@@ -181,12 +278,21 @@ resource "seqera_compute_env" "azure_batch" {
 
         head_pool                  = azurerm_batch_pool.pool.name
         managed_identity_client_id = data.azurerm_user_assigned_identity.mi.client_id
-        subnet_id                  = var.subnet_id
-        pre_run_script             = var.seqera_pre_run_script
-        post_run_script            = var.seqera_post_run_script
-        nextflow_config            = var.seqera_nextflow_config
-        enable_wave                = var.enable_fusion
-        enable_fusion              = var.enable_fusion
+
+        worker_pool = var.enable_dual_pool ? azurerm_batch_pool.worker[0].name : null
+
+        managed_identity_head_resource_id = var.enable_dual_pool ? data.azurerm_user_assigned_identity.mi.id : null
+        managed_identity_pool_client_id   = var.enable_dual_pool ? local.worker_identity_client_id : null
+        managed_identity_pool_resource_id = var.enable_dual_pool ? local.worker_identity_id : null
+
+        subnet_id       = var.subnet_id
+        pre_run_script  = var.seqera_pre_run_script
+        post_run_script = var.seqera_post_run_script
+        nextflow_config = var.seqera_nextflow_config
+        # Fusion requires Wave, so enabling Fusion implies Wave. Wave can also
+        # be enabled on its own via var.enable_wave.
+        enable_wave   = var.enable_wave || var.enable_fusion
+        enable_fusion = var.enable_fusion
       }
     }
   }
@@ -197,8 +303,14 @@ data "azurerm_resource_group" "rg" {
   name = var.resource_group_name
 }
 
-# Get managed identity details
+# Get managed identity details (head pool / Nextflow driver)
 data "azurerm_user_assigned_identity" "mi" {
   name                = var.managed_identity_name
   resource_group_name = var.managed_identity_resource_group
+}
+
+data "azurerm_user_assigned_identity" "worker_mi" {
+  count               = local.use_separate_worker_identity ? 1 : 0
+  name                = var.worker_managed_identity_name
+  resource_group_name = coalesce(var.worker_managed_identity_resource_group, var.managed_identity_resource_group)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,21 @@ output "batch_pool_id" {
   value       = azurerm_batch_pool.pool.id
 }
 
+output "worker_pool_name" {
+  description = "The name of the worker Azure Batch pool (null unless dual pool mode is enabled)"
+  value       = var.enable_dual_pool ? azurerm_batch_pool.worker[0].name : null
+}
+
+output "worker_pool_id" {
+  description = "The ID of the worker Azure Batch pool (null unless dual pool mode is enabled)"
+  value       = var.enable_dual_pool ? azurerm_batch_pool.worker[0].id : null
+}
+
+output "worker_managed_identity_client_id" {
+  description = "The client ID of the managed identity used by the worker pool (null unless dual pool mode is enabled)"
+  value       = var.enable_dual_pool ? local.worker_identity_client_id : null
+}
+
 output "managed_identity_client_id" {
   description = "The client ID of the managed identity"
   value       = data.azurerm_user_assigned_identity.mi.client_id

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "max_pool_size" {
   description = "Maximum number of VMs in the pool"
   type        = number
   default     = 8
+
+  validation {
+    condition     = var.max_pool_size >= var.min_pool_size
+    error_message = "max_pool_size must be greater than or equal to min_pool_size."
+  }
 }
 
 variable "vm_image_publisher" {
@@ -99,7 +104,13 @@ variable "start_task_scope" {
 }
 
 variable "enable_fusion" {
-  description = "Enable Fusion v2 support in the compute environment."
+  description = "Enable Fusion v2 support in the compute environment. Implies enable_wave (Fusion requires Wave)."
+  type        = bool
+  default     = false
+}
+
+variable "enable_wave" {
+  description = "Enable the Wave container service in the compute environment. Automatically enabled when enable_fusion is true; set independently to use Wave without Fusion."
   type        = bool
   default     = false
 }
@@ -126,6 +137,11 @@ variable "min_pool_size" {
   description = "Minimum number of VMs in the pool"
   type        = number
   default     = 0
+
+  validation {
+    condition     = var.min_pool_size >= 0
+    error_message = "min_pool_size must be greater than or equal to 0."
+  }
 }
 
 variable "container_registries" {
@@ -161,6 +177,67 @@ variable "create_seqera_compute_env" {
   description = "Whether to create a seqera compute environment"
   type        = bool
   default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Dual pool mode
+# -----------------------------------------------------------------------------
+
+variable "enable_dual_pool" {
+  description = "Enable dual pool mode: create a separate worker pool alongside the existing (head) pool. The head pool runs the Nextflow driver job and tasks are routed to the worker pool. Defaults to false, in which case the module behaves exactly as before (single pool)."
+  type        = bool
+  default     = false
+}
+
+variable "worker_pool_name" {
+  description = "Name of the worker Batch pool (dual pool mode). Defaults to '<batch_pool_name>-worker' if not set."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.worker_pool_name == null || var.worker_pool_name != var.batch_pool_name
+    error_message = "worker_pool_name must differ from batch_pool_name; the head and worker pools cannot share a name."
+  }
+}
+
+variable "worker_vm_size" {
+  description = "VM size for the worker pool (dual pool mode). Defaults to Standard_E16d_v5 (the same default as the head vm_size); set explicitly to give workers a different size than the head node."
+  type        = string
+  default     = "Standard_E16d_v5"
+}
+
+variable "worker_min_pool_size" {
+  description = "Minimum number of VMs in the worker pool (dual pool mode)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.worker_min_pool_size >= 0
+    error_message = "worker_min_pool_size must be greater than or equal to 0."
+  }
+}
+
+variable "worker_max_pool_size" {
+  description = "Maximum number of VMs in the worker pool (dual pool mode)."
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.worker_max_pool_size >= var.worker_min_pool_size
+    error_message = "worker_max_pool_size must be greater than or equal to worker_min_pool_size."
+  }
+}
+
+variable "worker_managed_identity_name" {
+  description = "Name of a separate managed identity for the worker pool (dual pool mode). Recommended for the security benefit of dual pool mode. If null, the worker pool reuses the head managed identity."
+  type        = string
+  default     = null
+}
+
+variable "worker_managed_identity_resource_group" {
+  description = "Resource group containing the worker managed identity. Defaults to managed_identity_resource_group if not set."
+  type        = string
+  default     = null
 }
 
 variable "seqera_api_endpoint" {


### PR DESCRIPTION
## Why
Nextflow's driver job and task execution currently share one Batch pool. Splitting them into separate head/worker pools improves security isolation (each pool can use its own managed identity) and lets worker VM size/scaling be tuned independently of the head node.

## What
- Add `enable_dual_pool` variable to optionally create a second `azurerm_batch_pool.worker` pool alongside the existing pool
- New variables: `worker_pool_name`, `worker_vm_size`, `worker_min_pool_size`, `worker_max_pool_size`, `worker_managed_identity_name`, `worker_managed_identity_resource_group`, with validation rules
- Wire worker pool into `seqera_compute_env` (`worker_pool`, separate managed identity fields for head/worker)
- Add standalone `enable_wave` variable (Fusion now implies Wave rather than reusing the same flag)
- Add `min_pool_size <= max_pool_size` validation for the head pool
- Update README (terraform-docs) and outputs for new resources/variables
- Defaults to `false`, so existing single-pool deployments are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)